### PR TITLE
Rework Standards (again)

### DIFF
--- a/src/api/generated/apis/TimetrialsApi.ts
+++ b/src/api/generated/apis/TimetrialsApi.ts
@@ -29,6 +29,7 @@ import type {
   ScoreSubmission,
   ScoreWithPlayer,
   SiteChampion,
+  Standard,
   StandardLevel,
   Track,
   TrackCup,
@@ -62,6 +63,8 @@ import {
     ScoreWithPlayerToJSON,
     SiteChampionFromJSON,
     SiteChampionToJSON,
+    StandardFromJSON,
+    StandardToJSON,
     StandardLevelFromJSON,
     StandardLevelToJSON,
     TrackFromJSON,
@@ -140,7 +143,7 @@ export interface TimetrialsScoresLatestListRequest {
 }
 
 export interface TimetrialsStandardsListRequest {
-    isLegacy?: boolean;
+    category: TimetrialsStandardsListCategoryEnum;
 }
 
 export interface TimetrialsSubmissionsCreateCreateRequest {
@@ -812,11 +815,42 @@ export class TimetrialsApi extends runtime.BaseAPI {
 
     /**
      */
-    async timetrialsStandardsListRaw(requestParameters: TimetrialsStandardsListRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<StandardLevel>>> {
+    async timetrialsStandardlevelsListRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<StandardLevel>>> {
         const queryParameters: any = {};
 
-        if (requestParameters['isLegacy'] != null) {
-            queryParameters['is_legacy'] = requestParameters['isLegacy'];
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        const response = await this.request({
+            path: `/api/timetrials/standardlevels/`,
+            method: 'GET',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(StandardLevelFromJSON));
+    }
+
+    /**
+     */
+    async timetrialsStandardlevelsList(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<StandardLevel>> {
+        const response = await this.timetrialsStandardlevelsListRaw(initOverrides);
+        return await response.value();
+    }
+
+    /**
+     */
+    async timetrialsStandardsListRaw(requestParameters: TimetrialsStandardsListRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Standard>>> {
+        if (requestParameters['category'] == null) {
+            throw new runtime.RequiredError(
+                'category',
+                'Required parameter "category" was null or undefined when calling timetrialsStandardsList().'
+            );
+        }
+
+        const queryParameters: any = {};
+
+        if (requestParameters['category'] != null) {
+            queryParameters['category'] = requestParameters['category'];
         }
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -828,12 +862,12 @@ export class TimetrialsApi extends runtime.BaseAPI {
             query: queryParameters,
         }, initOverrides);
 
-        return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(StandardLevelFromJSON));
+        return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(StandardFromJSON));
     }
 
     /**
      */
-    async timetrialsStandardsList(requestParameters: TimetrialsStandardsListRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<StandardLevel>> {
+    async timetrialsStandardsList(requestParameters: TimetrialsStandardsListRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<Standard>> {
         const response = await this.timetrialsStandardsListRaw(requestParameters, initOverrides);
         return await response.value();
     }
@@ -1457,6 +1491,15 @@ export const TimetrialsRegionsRankingsListTypeEnum = {
     Subnational: 'subnational'
 } as const;
 export type TimetrialsRegionsRankingsListTypeEnum = typeof TimetrialsRegionsRankingsListTypeEnum[keyof typeof TimetrialsRegionsRankingsListTypeEnum];
+/**
+ * @export
+ */
+export const TimetrialsStandardsListCategoryEnum = {
+    NonShortcut: 'nonsc',
+    Shortcut: 'sc',
+    Unrestricted: 'unres'
+} as const;
+export type TimetrialsStandardsListCategoryEnum = typeof TimetrialsStandardsListCategoryEnum[keyof typeof TimetrialsStandardsListCategoryEnum];
 /**
  * @export
  */

--- a/src/api/generated/models/StandardLevel.ts
+++ b/src/api/generated/models/StandardLevel.ts
@@ -13,13 +13,6 @@
  */
 
 import { mapValues } from '../runtime';
-import type { Standard } from './Standard';
-import {
-    StandardFromJSON,
-    StandardFromJSONTyped,
-    StandardToJSON,
-} from './Standard';
-
 /**
  * 
  * @export
@@ -39,23 +32,17 @@ export interface StandardLevel {
      */
     name: string;
     /**
+     * 
+     * @type {string}
+     * @memberof StandardLevel
+     */
+    code: string;
+    /**
      * Points awarded for achieving this standard level. The lower the better.
      * @type {number}
      * @memberof StandardLevel
      */
     value: number;
-    /**
-     * Whether this was part of the original 2010s standard set.
-     * @type {boolean}
-     * @memberof StandardLevel
-     */
-    isLegacy: boolean;
-    /**
-     * 
-     * @type {Array<Standard>}
-     * @memberof StandardLevel
-     */
-    readonly standards: Array<Standard>;
 }
 
 /**
@@ -64,9 +51,8 @@ export interface StandardLevel {
 export function instanceOfStandardLevel(value: object): value is StandardLevel {
     if (!('id' in value) || value['id'] === undefined) return false;
     if (!('name' in value) || value['name'] === undefined) return false;
+    if (!('code' in value) || value['code'] === undefined) return false;
     if (!('value' in value) || value['value'] === undefined) return false;
-    if (!('isLegacy' in value) || value['isLegacy'] === undefined) return false;
-    if (!('standards' in value) || value['standards'] === undefined) return false;
     return true;
 }
 
@@ -82,21 +68,20 @@ export function StandardLevelFromJSONTyped(json: any, ignoreDiscriminator: boole
         
         'id': json['id'],
         'name': json['name'],
+        'code': json['code'],
         'value': json['value'],
-        'isLegacy': json['is_legacy'],
-        'standards': ((json['standards'] as Array<any>).map(StandardFromJSON)),
     };
 }
 
-export function StandardLevelToJSON(value?: Omit<StandardLevel, 'id'|'standards'> | null): any {
+export function StandardLevelToJSON(value?: Omit<StandardLevel, 'id'> | null): any {
     if (value == null) {
         return value;
     }
     return {
         
         'name': value['name'],
+        'code': value['code'],
         'value': value['value'],
-        'is_legacy': value['isLegacy'],
     };
 }
 

--- a/src/components/App.scss
+++ b/src/components/App.scss
@@ -1,6 +1,9 @@
 @mixin recursive-tr($n) {
   + tr {
     background-color: var(--header-background-color);
+    td {
+      background-color: var(--header-background-color);
+    }
     @if $n > 2 {
       @include recursive-tr($n - 1);
     }

--- a/src/components/pages/PlayerProfilePage.tsx
+++ b/src/components/pages/PlayerProfilePage.tsx
@@ -20,6 +20,7 @@ import {
   translate,
   translateRegionName,
   translateRegionNameFull,
+  translateStandardName,
   translateTrack,
 } from "../../utils/i18n/i18n";
 import { SettingsContext } from "../../utils/Settings";
@@ -182,7 +183,7 @@ const PlayerProfilePage = () => {
           className: timeClassName + " overall-hidden",
         },
         { content: score.rank },
-        { content: getStandardLevel(metadata, score.standard)?.name },
+        { content: translateStandardName(getStandardLevel(metadata, score.standard), lang) },
         { content: (score.recordRatio * 100).toFixed(2) + "%" },
         {
           content: (

--- a/src/components/pages/TrackChartPage.tsx
+++ b/src/components/pages/TrackChartPage.tsx
@@ -21,7 +21,12 @@ import {
   useRowHighlightParam,
 } from "../../utils/SearchParams";
 import { LapModeEnum, LapModeRadio } from "../widgets/LapModeSelect";
-import { I18nContext, translate, translateTrack } from "../../utils/i18n/i18n";
+import {
+  I18nContext,
+  translate,
+  translateStandardName,
+  translateTrack,
+} from "../../utils/i18n/i18n";
 import { SettingsContext } from "../../utils/Settings";
 import PlayerMention from "../widgets/PlayerMention";
 import { CategoryRadio } from "../widgets/CategorySelect";
@@ -137,7 +142,7 @@ const TrackChartPage = () => {
         content: formatTime(score.value),
         className: score.category !== category ? "fallthrough" : undefined,
       },
-      { content: getStandardLevel(metadata, score.standard)?.name },
+      { content: translateStandardName(getStandardLevel(metadata, score.standard), lang) },
       {
         content: score.date ? (
           <FormatDateDependable

--- a/src/components/pages/TrackRecordsPage.tsx
+++ b/src/components/pages/TrackRecordsPage.tsx
@@ -13,7 +13,13 @@ import { useCategoryParam, useLapModeParam, useRegionParam } from "../../utils/S
 import { UserContext } from "../../utils/User";
 import { getStandardLevel, MetadataContext } from "../../utils/Metadata";
 import RegionSelectionDropdown from "../widgets/RegionDropdown";
-import { I18nContext, translate, translateRegionName, translateTrack } from "../../utils/i18n/i18n";
+import {
+  I18nContext,
+  translate,
+  translateRegionName,
+  translateStandardName,
+  translateTrack,
+} from "../../utils/i18n/i18n";
 import { SettingsContext } from "../../utils/Settings";
 import PlayerMention from "../widgets/PlayerMention";
 import { CategoryRadio } from "../widgets/CategorySelect";
@@ -131,7 +137,10 @@ const TrackRecordsPage = () => {
         out[Indexes.TimeCellSmall].className = "track-records-columns-s1";
         out[isLap ? Indexes.LapTimeCellBig : Indexes.CourseTimeCellBig].className =
           "track-records-columns-b1";
-        out[Indexes.Standards].content = getStandardLevel(metadata, score.standard)?.name;
+        out[Indexes.Standards].content = translateStandardName(
+          getStandardLevel(metadata, score.standard),
+          lang,
+        );
         if (score.date) {
           out[Indexes.Date].content = (
             <FormatDateDependable

--- a/src/components/pages/standards/StandardsPage.css
+++ b/src/components/pages/standards/StandardsPage.css
@@ -1,5 +1,9 @@
 .table-track-col {
-  display: var(--track-selected);
+  display: var(--track-selected) !important;
+}
+
+.table-category-col {
+  display: var(--category-selected) !important;
 }
 
 .table-s1,

--- a/src/components/pages/standards/StandardsPage.tsx
+++ b/src/components/pages/standards/StandardsPage.tsx
@@ -54,7 +54,7 @@ const StandardDropdown = ({ levelId, setLevelId }: StandardDropdownProps) => {
   const standardsData: DropdownItemSetDataChild[] = metadata.standardLevels?.map((l) => {
     return {
       type: "DropdownItemData",
-      element: { text: l.name, value: l.id },
+      element: { text: translateStandardName(l, lang), value: l.id },
     } as DropdownItemSetDataChild;
   }) ?? [
     { type: "DropdownItemData", element: { text: "God", value: 1 } },
@@ -245,10 +245,7 @@ const StandardsPage = () => {
             className: "table-b2",
           },
           {
-            content: translateStandardName(
-              getStandardLevel(metadata, standard.level)?.code ?? "NW",
-              lang,
-            ),
+            content: translateStandardName(getStandardLevel(metadata, standard), lang),
           },
           { content: standard.isLap ? null : value, className: "table-b1" },
           { content: value, expandCell: [false, !standard.isLap], className: "table-b1" },
@@ -335,7 +332,7 @@ const StandardsPage = () => {
                     secondTableData.classNames?.push({ rowIdx: idx, className: "highlighted" });
                   return [
                     {
-                      content: translateStandardName(l.code, lang),
+                      content: translateStandardName(l, lang),
                     },
                     { content: l.value },
                   ];

--- a/src/components/pages/standards/StandardsPage.tsx
+++ b/src/components/pages/standards/StandardsPage.tsx
@@ -5,10 +5,10 @@ import "./StandardsPage.css";
 
 import { Pages, resolvePage } from "../Pages";
 import Deferred from "../../widgets/Deferred";
-import { getCategoryNumerical, getCategorySiteHue } from "../../../utils/EnumUtils";
+import { getCategorySiteHue } from "../../../utils/EnumUtils";
 import { formatTime } from "../../../utils/Formatters";
-import { MetadataContext } from "../../../utils/Metadata";
-import api, { Standard } from "../../../api";
+import { getStandardLevel, MetadataContext } from "../../../utils/Metadata";
+import api from "../../../api";
 import OverwriteColor from "../../widgets/OverwriteColor";
 import Dropdown, {
   DropdownData,
@@ -25,6 +25,7 @@ import {
   I18nContext,
   translate,
   translateCategoryName,
+  translateStandardName,
   translateTrack,
 } from "../../../utils/i18n/i18n";
 import { SettingsContext } from "../../../utils/Settings";
@@ -50,7 +51,7 @@ const StandardDropdown = ({ levelId, setLevelId }: StandardDropdownProps) => {
   const metadata = useContext(MetadataContext);
   const { lang } = useContext(I18nContext);
 
-  const standardsData: DropdownItemSetDataChild[] = metadata.standards?.map((l) => {
+  const standardsData: DropdownItemSetDataChild[] = metadata.standardLevels?.map((l) => {
     return {
       type: "DropdownItemData",
       element: { text: l.name, value: l.id },
@@ -135,10 +136,6 @@ const Filter: Record<number, number[]> = {
   42: [30, 31, 32, 33],
 };
 
-interface StandardWithName extends Standard {
-  name: string;
-}
-
 const StandardsPage = () => {
   const searchParams = useSearchParams();
   const { category, setCategory } = useCategoryParam(searchParams);
@@ -150,6 +147,12 @@ const StandardsPage = () => {
   const metadata = useContext(MetadataContext);
   const { settings } = useContext(SettingsContext);
   const { user } = useContext(UserContext);
+
+  const { data: standards, isLoading: standardsLoading } = useApi(
+    () => api.timetrialsStandardsList({ category }),
+    [category],
+    "standards",
+  );
 
   const { data: userScores, isLoading: scoresLoading } = useApi(
     () => api.timetrialsPlayersScoresList({ category, id: user?.player ?? 1 }),
@@ -169,96 +172,89 @@ const StandardsPage = () => {
     "playerProfileStats",
   );
 
-  const level: { standards: StandardWithName[] } = { standards: [] };
-  metadata.standards
-    ?.filter((l) =>
-      levelId < 35 ? l.id === levelId : levelId === 43 || Filter[levelId].includes(l.id),
-    )
-    .forEach((l) => {
-      const newLevel = l.standards.map((r) => {
-        (r as StandardWithName).name = l.name;
-        return r;
-      });
-      level.standards.push(...(newLevel as unknown as StandardWithName[]));
-    });
-
   const tableData: ArrayTableData = { classNames: [] };
 
-  const filteredStandards: ArrayTableCellData[][] = level?.standards
-    .filter(
-      (r, _, arr) =>
-        r.name !== "Newbie" &&
-        (r.category === category ||
-          arr
-            .filter((j) => j.category <= category && r.track === j.track && r.isLap === j.isLap)
-            .sort((a, b) => getCategoryNumerical(a.category) - getCategoryNumerical(b.category))
-            .at(-1)?.id === r.id) &&
-        (track === -5 || r.track === track),
-    )
-    .sort((a, b) => a.track - b.track || a.level - b.level || (a.isLap ? 1 : 0) - (b.isLap ? 1 : 0))
-    .map((standard, idx, arr) => {
-      const track = metadata.tracks?.find((track) => track.id === standard.track);
-      const value = formatTime(standard.value ?? 0);
-
-      if (
-        user &&
-        !scoresLoading &&
-        (standard.value ?? 0) >
-          (userScores?.find(
-            (score) =>
-              standard.category >= score.category &&
-              standard.track === score.track &&
-              score.isLap === standard.isLap,
-          )?.value ?? 360000)
+  const filteredStandards: ArrayTableCellData[][] =
+    standards
+      ?.filter(
+        (standard, _, arr) =>
+          standard.level !== 34 &&
+          (levelId < 34
+            ? standard.level === levelId
+            : levelId === 43 || Filter[levelId].includes(standard.level)) &&
+          (track === -5 || standard.track === track),
       )
-        tableData.classNames?.push({ rowIdx: idx, className: "highlighted" });
+      .sort(
+        (a, b) => a.track - b.track || a.level - b.level || (a.isLap ? 1 : 0) - (b.isLap ? 1 : 0),
+      )
+      .map((standard, idx, arr) => {
+        const track = metadata.tracks?.find((track) => track.id === standard.track);
+        const value = formatTime(standard.value ?? 0);
 
-      return [
-        {
-          content: (
-            <Link
-              to={resolvePage(
-                Pages.TrackChart,
-                { id: standard.track },
-                { lap: standard.isLap ? LapModeEnum.Lap : null },
-              )}
-            >
-              {translateTrack(track, lang)}
-            </Link>
-          ),
-          className: "table-track-col table-b1",
-          expandCell: [
-            arr[idx - 1] && standard.isLap && arr[idx - 1].track === standard.track,
-            false,
-          ],
-        },
-        {
-          content: (
-            <Link
-              to={resolvePage(
-                Pages.TrackChart,
-                { id: standard.track },
-                { lap: standard.isLap ? LapModeEnum.Lap : null },
-              )}
-            >
-              <>
-                <span className="table-b3">{translateTrack(track, lang)}</span>
-                <span className="table-s3">{track?.abbr}</span>
-              </>
-            </Link>
-          ),
-          className: "table-track-col table-s1",
-        },
-        {
-          content: translateCategoryName(standard.category, lang),
-          className: "table-b2",
-        },
-        { content: standard.name },
-        { content: standard.isLap ? null : value, className: "table-b1" },
-        { content: value, expandCell: [false, !standard.isLap], className: "table-b1" },
-        { content: value, className: "table-s1" },
-      ] as ArrayTableCellData[];
-    });
+        if (
+          user &&
+          !scoresLoading &&
+          (standard.value ?? 0) >
+            (userScores?.find(
+              (score) =>
+                standard.category >= score.category &&
+                standard.track === score.track &&
+                score.isLap === standard.isLap,
+            )?.value ?? 360000)
+        )
+          tableData.classNames?.push({ rowIdx: idx, className: "highlighted" });
+
+        return [
+          {
+            content: (
+              <Link
+                to={resolvePage(
+                  Pages.TrackChart,
+                  { id: standard.track },
+                  { lap: standard.isLap ? LapModeEnum.Lap : null },
+                )}
+              >
+                {translateTrack(track, lang)}
+              </Link>
+            ),
+            className: "table-track-col table-b1",
+            expandCell: [
+              arr[idx - 1] && standard.isLap && arr[idx - 1].track === standard.track,
+              false,
+            ],
+          },
+          {
+            content: (
+              <Link
+                to={resolvePage(
+                  Pages.TrackChart,
+                  { id: standard.track },
+                  { lap: standard.isLap ? LapModeEnum.Lap : null },
+                )}
+              >
+                <>
+                  <span className="table-b3">{translateTrack(track, lang)}</span>
+                  <span className="table-s3">{track?.abbr}</span>
+                </>
+              </Link>
+            ),
+            className: "table-track-col table-s1",
+          },
+          {
+            content: translateCategoryName(standard.category, lang),
+            className: "table-b2",
+          },
+          {
+            content: translateStandardName(
+              getStandardLevel(metadata, standard.level)?.code ?? "NW",
+              lang,
+            ),
+          },
+          { content: standard.isLap ? null : value, className: "table-b1" },
+          { content: value, expandCell: [false, !standard.isLap], className: "table-b1" },
+          { content: value, className: "table-s1" },
+        ] as ArrayTableCellData[];
+      }) ?? [];
 
   const siteHue = getCategorySiteHue(category, settings);
 
@@ -280,7 +276,7 @@ const StandardsPage = () => {
             { "--track-selected": track === -5 ? "table-cell" : "none" } as React.CSSProperties
           }
         >
-          <Deferred isWaiting={metadata.isLoading || scoresLoading}>
+          <Deferred isWaiting={metadata.isLoading || scoresLoading || standardsLoading}>
             <ArrayTable
               headerRows={[
                 [
@@ -330,7 +326,7 @@ const StandardsPage = () => {
                 ],
               ]}
               rows={
-                metadata.standards?.map((l, idx) => {
+                metadata.standardLevels?.map((l, idx) => {
                   if (
                     user &&
                     !userStatsLoading &&
@@ -339,7 +335,7 @@ const StandardsPage = () => {
                     secondTableData.classNames?.push({ rowIdx: idx, className: "highlighted" });
                   return [
                     {
-                      content: l.name,
+                      content: translateStandardName(l.code, lang),
                     },
                     { content: l.value },
                   ];

--- a/src/components/pages/standards/StandardsPage.tsx
+++ b/src/components/pages/standards/StandardsPage.tsx
@@ -174,6 +174,8 @@ const StandardsPage = () => {
 
   const tableData: ArrayTableData = { classNames: [] };
 
+  let hasHighlightedRow = [false, false];
+
   const filteredStandards: ArrayTableCellData[][] =
     standards
       ?.filter(
@@ -191,18 +193,23 @@ const StandardsPage = () => {
         const track = metadata.tracks?.find((track) => track.id === standard.track);
         const value = formatTime(standard.value ?? 0);
 
+        if (idx > 0 && arr[idx - 1].track !== standard.track) hasHighlightedRow = [false, false];
+
         if (
+          !hasHighlightedRow[+(standard?.isLap ?? false)] &&
           user &&
           !scoresLoading &&
           (standard.value ?? 0) >
             (userScores?.find(
               (score) =>
-                standard.category >= score.category &&
                 standard.track === score.track &&
-                score.isLap === standard.isLap,
+                score.isLap === standard.isLap &&
+                category >= score.category,
             )?.value ?? 360000)
-        )
+        ) {
+          hasHighlightedRow[+(standard?.isLap ?? false)] = true;
           tableData.classNames?.push({ rowIdx: idx, className: "highlighted" });
+        }
 
         return [
           {
@@ -218,10 +225,7 @@ const StandardsPage = () => {
               </Link>
             ),
             className: "table-track-col table-b1",
-            expandCell: [
-              arr[idx - 1] && standard.isLap && arr[idx - 1].track === standard.track,
-              false,
-            ],
+            expandCell: [idx > 0 && standard.isLap && arr[idx - 1].track === standard.track, false],
           },
           {
             content: (

--- a/src/components/pages/standards/StandardsPage.tsx
+++ b/src/components/pages/standards/StandardsPage.tsx
@@ -8,7 +8,7 @@ import Deferred from "../../widgets/Deferred";
 import { getCategorySiteHue } from "../../../utils/EnumUtils";
 import { formatTime } from "../../../utils/Formatters";
 import { getStandardLevel, MetadataContext } from "../../../utils/Metadata";
-import api from "../../../api";
+import api, { CategoryEnum } from "../../../api";
 import OverwriteColor from "../../widgets/OverwriteColor";
 import Dropdown, {
   DropdownData,
@@ -246,7 +246,7 @@ const StandardsPage = () => {
           },
           {
             content: translateCategoryName(standard.category, lang),
-            className: "table-b2",
+            className: "table-b2 table-category-col",
           },
           {
             content: translateStandardName(getStandardLevel(metadata, standard), lang),
@@ -274,7 +274,10 @@ const StandardsPage = () => {
         <div
           className={`module standards-table ${lapMode.toLowerCase()}`}
           style={
-            { "--track-selected": track === -5 ? "table-cell" : "none" } as React.CSSProperties
+            {
+              "--track-selected": track === -5 ? "table-cell" : "none",
+              "--category-selected": category === CategoryEnum.NonShortcut ? "none" : "table-cell",
+            } as React.CSSProperties
           }
         >
           <Deferred isWaiting={metadata.isLoading || scoresLoading || standardsLoading}>
@@ -291,7 +294,7 @@ const StandardsPage = () => {
                   },
                   {
                     content: translate("standardsPageCategoryCol", lang),
-                    className: "table-b2",
+                    className: "table-category-col table-b2",
                   },
                   { content: translate("standardsPageStandardCol", lang) },
                   {

--- a/src/utils/Metadata.ts
+++ b/src/utils/Metadata.ts
@@ -1,6 +1,6 @@
 import { createContext } from "react";
 
-import api, { Region, Track, TrackCup, StandardLevel } from "../api";
+import api, { Region, Track, TrackCup, StandardLevel, Standard } from "../api";
 import { useApi } from "../hooks";
 import { WorldRegion } from "./Defaults";
 
@@ -8,7 +8,7 @@ import { WorldRegion } from "./Defaults";
 export interface Metadata {
   isLoading: boolean;
   regions: Region[];
-  standards?: StandardLevel[];
+  standardLevels?: StandardLevel[];
   cups?: TrackCup[];
   tracks?: Track[];
 }
@@ -19,14 +19,14 @@ export interface Metadata {
  */
 export const useMetadata = (): Metadata => {
   const regions = useApi(() => api.timetrialsRegionsList(), [], "regions");
-  const standards = useApi(() => api.timetrialsStandardsList(), [], "standards");
+  const standards = useApi(() => api.timetrialsStandardlevelsList(), [], "standardLevels");
   const cups = useApi(() => api.timetrialsCupsList(), [], "cups");
   const tracks = useApi(() => api.timetrialsTracksList(), [], "tracks");
 
   return {
     isLoading: regions.isLoading || standards.isLoading || cups.isLoading || tracks.isLoading,
     regions: regions.data ?? [WorldRegion],
-    standards: standards.data,
+    standardLevels: standards.data,
     cups: cups.data,
     tracks: tracks.data,
   };
@@ -56,20 +56,12 @@ export const getRegionById = (metadata: Metadata, regionId: number) => {
  * @param standardId The id of the standard
  * @returns A StandardLevel object, or `undefined` if no standard with the given id exists.
  */
-export const getStandardLevel = (metadata: Metadata, standardId: number) => {
-  if (!metadata.standards) {
+export const getStandardLevel = (metadata: Metadata, standard: Standard | number) => {
+  if (!metadata.standardLevels) {
     return undefined;
   }
-
-  // This is obviously inefficient but this doesn't appear to cause any measurable slow downs...
-  for (const level of metadata.standards) {
-    const standard = level.standards.find((s) => s.id === standardId);
-    if (standard) {
-      return level;
-    }
-  }
-
-  return undefined;
+  if (typeof standard === "number") return metadata.standardLevels.find((s) => s.id === standard);
+  return metadata.standardLevels.find((s) => s.id === standard.level);
 };
 
 /**

--- a/src/utils/i18n/i18n.json
+++ b/src/utils/i18n/i18n.json
@@ -13383,7 +13383,7 @@
     "es": ""
   },
   "standardsPageStandardDropdownAllMyth": {
-    "it": "Tutti i Myth",
+    "it": "Tutti i Mito",
     "en": "All Myth",
     "fr": "",
     "de": "",
@@ -13392,7 +13392,7 @@
     "es": ""
   },
   "standardsPageStandardDropdownAllLegend": {
-    "it": "Tutti i Legend",
+    "it": "Tutti i Leggenda",
     "en": "All Legend",
     "fr": "",
     "de": "",
@@ -13401,7 +13401,7 @@
     "es": ""
   },
   "standardsPageStandardDropdownAllKing": {
-    "it": "Tutti i King",
+    "it": "Tutti i Re",
     "en": "All King",
     "fr": "",
     "de": "",
@@ -13410,7 +13410,7 @@
     "es": ""
   },
   "standardsPageStandardDropdownAllHero": {
-    "it": "Tutti gli Hero",
+    "it": "Tutti gli Eroe",
     "en": "All Hero",
     "fr": "",
     "de": "",
@@ -13419,7 +13419,7 @@
     "es": ""
   },
   "standardsPageStandardDropdownAllExpert": {
-    "it": "Tutti gli Expert",
+    "it": "Tutti gli Esperto",
     "en": "All Expert",
     "fr": "",
     "de": "",
@@ -13428,7 +13428,7 @@
     "es": ""
   },
   "standardsPageStandardDropdownAllIntermediate": {
-    "it": "Tutti gli Intermediate",
+    "it": "Tutti gli Intermedio",
     "en": "All Intermediate",
     "fr": "",
     "de": "",
@@ -13437,7 +13437,7 @@
     "es": ""
   },
   "standardsPageStandardDropdownAllApprentice": {
-    "it": "Tutti gli Apprentice",
+    "it": "Tutti gli Apprendista",
     "en": "All Apprentice",
     "fr": "",
     "de": "",
@@ -13446,7 +13446,7 @@
     "es": ""
   },
   "standardsPageStandardDropdownAllBeginner": {
-    "it": "Tutti i Beginner",
+    "it": "Tutti i Principiante",
     "en": "All Beginner",
     "fr": "",
     "de": "",

--- a/src/utils/i18n/i18n.json
+++ b/src/utils/i18n/i18n.json
@@ -440,6 +440,312 @@
     "pt": "",
     "es": "N64 Castillo de Bowser"
   },
+  "constantStandardLevelGD": {
+    "it": "Dio",
+    "en": "God",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelMA": {
+    "it": "Mito A",
+    "en": "Myth A",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelMB": {
+    "it": "Mito B",
+    "en": "Myth B",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelMC": {
+    "it": "Mito C",
+    "en": "Myth C",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelMD": {
+    "it": "Mito D",
+    "en": "Myth D",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelLA": {
+    "it": "Leggenda A",
+    "en": "Legend A",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelLB": {
+    "it": "Leggenda B",
+    "en": "Legend B",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelLC": {
+    "it": "Leggenda C",
+    "en": "Legend C",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelLD": {
+    "it": "Leggenda D",
+    "en": "Legend D",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelKA": {
+    "it": "Re A",
+    "en": "King A",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelKB": {
+    "it": "Re B",
+    "en": "King B",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelKC": {
+    "it": "Re C",
+    "en": "King C",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelKD": {
+    "it": "Re D",
+    "en": "King D",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelHA": {
+    "it": "Eroe A",
+    "en": "Hero A",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelHB": {
+    "it": "Eroe B",
+    "en": "Hero B",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelHC": {
+    "it": "Eroe C",
+    "en": "Hero C",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelHD": {
+    "it": "Eroe D",
+    "en": "Hero D",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelEA": {
+    "it": "Esperto A",
+    "en": "Expert A",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelEB": {
+    "it": "Esperto B",
+    "en": "Expert B",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelEC": {
+    "it": "Esperto C",
+    "en": "Expert C",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelED": {
+    "it": "Esperto D",
+    "en": "Expert D",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelIA": {
+    "it": "Intermedio A",
+    "en": "Intermediate A",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelIB": {
+    "it": "Intermedio B",
+    "en": "Intermediate B",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelIC": {
+    "it": "Intermedio C",
+    "en": "Intermediate C",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelID": {
+    "it": "Intermedio D",
+    "en": "Intermediate D",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelAA": {
+    "it": "Apprendista A",
+    "en": "Apprentice A",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelAB": {
+    "it": "Apprendista B",
+    "en": "Apprentice B",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelAC": {
+    "it": "Apprendista C",
+    "en": "Apprentice C",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelAD": {
+    "it": "Apprendista D",
+    "en": "Apprentice D",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelBA": {
+    "it": "Principiante A",
+    "en": "Beginner A",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelBB": {
+    "it": "Principiante B",
+    "en": "Beginner B",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelBC": {
+    "it": "Principiante C",
+    "en": "Beginner C",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelBD": {
+    "it": "Principiante D",
+    "en": "Beginner D",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
+  "constantStandardLevelNW": {
+    "it": "Novizio",
+    "en": "Newbie",
+    "fr": "",
+    "de": "",
+    "jp": "",
+    "pt": "",
+    "es": ""
+  },
   "constantRegionXX": {
     "it": "Sconosciuta",
     "en": "Unknown",

--- a/src/utils/i18n/i18n.tsx
+++ b/src/utils/i18n/i18n.tsx
@@ -3,7 +3,7 @@ import { createContext, useContext } from "react";
 /* Keys are camel case, and should start with the file name for easy retrieval while editing. */
 import i18nJson from "./i18n.json";
 
-import { CategoryEnum, Region, RegionTypeEnum, Track } from "../../api";
+import { CategoryEnum, Region, RegionTypeEnum, StandardLevel, Track } from "../../api";
 import { getRegionById, Metadata } from "../Metadata";
 import { browserSettingsLoadParse } from "../Settings";
 import { LapModeEnum } from "../../components/widgets/LapModeSelect";
@@ -193,4 +193,11 @@ export const translateLapModeName = (lapMode: LapModeEnum, lang: Language): stri
     case LapModeEnum.Overall:
       return translate("constantLapModeOverall", lang);
   }
+};
+
+export const translateStandardName = (
+  standardLevel: StandardLevel | undefined,
+  lang: Language,
+): string => {
+  return translate(`constantStandardLevel${standardLevel?.code ?? "NW"}` as TranslationKey, lang);
 };


### PR DESCRIPTION
## Changelog
- Updated translations for Standard Level Dropdown
- Added translations and translator function for Standard Levels
- Converted StandardsPage.tsx to use new endpoints
- Converted Metadata.ts to use new endpoints
- Converted other pages to use translations
- Edit highlighted rows so that only the highest beaten shown standard is highlighted
- Fix issue where the second row next to a rowspan=2 element wouldn't get the hover style when it's highlighted
- Hide category when the column is all No-SC
- Fix bug where Track Column would show up on small screen sizes when it's hidden