### PR TITLE
Ditch `initial_rank`

### DIFF
--- a/src/api/endpoints/scores.ts
+++ b/src/api/endpoints/scores.ts
@@ -51,7 +51,7 @@ export const LapModeEnumValues: LapModeEnum[] = [
 
 type ScoreByDate = Omit<
   Score,
-  "stdLvlCode" | "videoLink" | "ghostLink" | "comment" | "rank" | "prwr" | "initialRank"
+  "stdLvlCode" | "videoLink" | "ghostLink" | "comment" | "rank" | "prwr" | "wasWr"
 >;
 
 export class Score {
@@ -65,10 +65,10 @@ export class Score {
   readonly date: number;
   readonly rank: number;
   readonly prwr: number;
+  readonly wasWr: boolean;
   readonly videoLink?: string;
   readonly ghostLink?: string;
   readonly comment?: string;
-  readonly initialRank?: number;
 
   constructor(
     id: number,
@@ -84,7 +84,7 @@ export class Score {
     video_link?: string,
     ghost_link?: string,
     comment?: string,
-    initialRank?: number,
+    wasWr: boolean = false,
   ) {
     this.id = id;
     this.stdLvlCode = stdLvlCode;
@@ -99,7 +99,7 @@ export class Score {
     this.videoLink = video_link;
     this.ghostLink = ghost_link;
     this.comment = comment;
-    this.initialRank = initialRank;
+    this.wasWr = wasWr;
   }
 
   public static async getChart(
@@ -159,7 +159,7 @@ export class AdminScore {
   readonly ghostLink?: string;
   readonly comment?: string;
   readonly adminNote?: string;
-  readonly initialRank?: number;
+  readonly wasWr: boolean;
 
   constructor(
     id: number,
@@ -173,7 +173,7 @@ export class AdminScore {
     ghostLink?: string,
     comment?: string,
     adminNote?: string,
-    initialRank?: number,
+    wasWr: boolean = false,
   ) {
     this.id = id;
     this.value = value;
@@ -186,7 +186,7 @@ export class AdminScore {
     this.ghostLink = ghostLink;
     this.comment = comment;
     this.adminNote = adminNote;
-    this.initialRank = initialRank;
+    this.wasWr = wasWr;
   }
 
   public static async getList(trackId: number): Promise<Array<AdminScore> | null> {
@@ -230,7 +230,6 @@ export class AdminScore {
     ghostLink?: string,
     comment?: string,
     adminNote?: string,
-    initialRank?: number,
   ): Promise<boolean> {
     const sessionToken = getToken();
     if (sessionToken === null) return new Promise((res) => res(false));
@@ -254,7 +253,6 @@ export class AdminScore {
         ghostLink,
         comment,
         adminNote,
-        initialRank,
       },
     ).then((r) => r.success);
   }
@@ -271,7 +269,6 @@ export class AdminScore {
     ghostLink?: string,
     comment?: string,
     adminNote?: string,
-    initialRank?: number,
   ): Promise<boolean> {
     const sessionToken = getToken();
     if (sessionToken === null) return new Promise((res) => res(false));
@@ -296,7 +293,6 @@ export class AdminScore {
         ghostLink,
         comment,
         adminNote,
-        initialRank,
       },
     ).then((r) => r.success);
   }

--- a/src/components/pages/admin/scores/AdminScoresModule.tsx
+++ b/src/components/pages/admin/scores/AdminScoresModule.tsx
@@ -1,4 +1,4 @@
-import { Tooltip } from "@mui/material";
+import { Box, Switch, Tooltip } from "@mui/material";
 import dayjs, { Dayjs } from "dayjs";
 import { useContext, useState } from "react";
 import { useNavigate } from "react-router";
@@ -28,7 +28,6 @@ interface AdminScoreModuleState extends FormState {
   ghostLink?: string;
   comment?: string;
   adminNote?: string;
-  initialRank?: number;
 }
 
 const AdminScoreModule = ({ score }: AdminScoreModuleProps) => {
@@ -44,7 +43,6 @@ const AdminScoreModule = ({ score }: AdminScoreModuleProps) => {
     ghostLink: score?.ghostLink ?? "",
     comment: score?.comment ?? "",
     adminNote: score?.adminNote ?? "",
-    initialRank: score?.initialRank ?? 2147483647,
     errors: {},
     submitting: false,
   };
@@ -66,7 +64,6 @@ const AdminScoreModule = ({ score }: AdminScoreModuleProps) => {
           state.ghostLink === "" ? undefined : state.ghostLink,
           state.comment === "" ? undefined : state.comment,
           state.adminNote === "" ? undefined : state.adminNote,
-          state.initialRank === 2147483647 ? undefined : state.initialRank,
         )
     : async () =>
         AdminScore.insertScore(
@@ -80,7 +77,6 @@ const AdminScoreModule = ({ score }: AdminScoreModuleProps) => {
           state.ghostLink === "" ? undefined : state.ghostLink,
           state.comment === "" ? undefined : state.comment,
           state.adminNote === "" ? undefined : state.adminNote,
-          state.initialRank === 2147483647 ? undefined : state.initialRank,
         );
 
   const submit = () =>
@@ -138,7 +134,13 @@ const AdminScoreModule = ({ score }: AdminScoreModuleProps) => {
         <TextFormField field="ghostLink" label="Ghost Link" />
         <TextFormField field="comment" label="Comment" />
         <TextFormField field="adminNote" label="Admin Note" />
-        <TextFormField type="number" field="initialRank" label="Initial Rank" />
+        <Box>
+          <p>Was WR?</p>
+          <Switch disabled defaultChecked={score?.wasWr ?? false} />
+          <p>
+            This cannot be changed because it's recalculated by the backend every time to be correct
+          </p>
+        </Box>
       </Form>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -184,13 +184,13 @@ input[type="submit"]:hover {
   background-color: var(--input-background-color-hover);
 }
 
-input:disabled,
+input:disabled:not(.MuiSwitch-input),
 select:disabled {
   background-color: var(--input-background-color-disabled);
   opacity: 1;
 }
 
-input:disabled:hover,
+input:disabled:hover:not(.MuiSwitch-input),
 select:disabled:hover {
   background-color: var(--input-background-color-disabled-hover);
 }


### PR DESCRIPTION
If/Once this gets merged, I'll also merge https://github.com/MKW-Players-Page/mkwpp-api-rust/pull/51
The idea is that, while the `initial_rank` system is flawed, because initial_rank can be different depending on the category, and that makes `initial_rank` only usable in very few scenarios, `was_wr` can be used only in one very specific and clear scenario. It's also a lot faster to calculate and should make adding scores faster.